### PR TITLE
Fix zero crossing for single-sample audio

### DIFF
--- a/src/features/time.ts
+++ b/src/features/time.ts
@@ -188,6 +188,10 @@ export function getRMS(audio: AudioData, channel = 0): number {
 export function getZeroCrossing(audio: AudioData, channel = 0): number {
   const channelData = getChannelData(audio, channel);
 
+  if (channelData.length < 2) {
+    return 0;
+  }
+
   let crossings = 0;
   for (let i = 1; i < channelData.length; i++) {
     const prev = channelData[i - 1] as number;

--- a/test/features/time.test.ts
+++ b/test/features/time.test.ts
@@ -389,6 +389,15 @@ describe('getZeroCrossing', () => {
     // 2 zero crossings in 4 transitions
     expect(zcr).toBe(2 / 4);
   });
+
+  it('should return 0 for audio shorter than 2 samples', () => {
+    const data = new Float32Array([1]);
+    const audio = createTestAudioData(data);
+
+    const zcr = getZeroCrossing(audio);
+
+    expect(zcr).toBe(0);
+  });
 });
 
 describe('getWaveform', () => {


### PR DESCRIPTION
## Summary
- prevent `getZeroCrossing` from returning `Infinity` on audio shorter than two samples
- test zero crossing for single-sample input

## Testing
- `npm test`